### PR TITLE
Closing statement in PdfEngine combine() function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__/
 *.epub
 *.pdf
-*/
+venv/*

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ After this, you install the _wkhtmltopdf_ which is a dependency of the _pdfkit_ 
 
 wkhtmltopdf file can be downloaded [here](https://wkhtmltopdf.org/downloads.html)
 
+Make sure to add wkhtlmtopdf as an executable in Windows environment paths.
+
 For Debian/Ubuntu users:
 
 
-```$ sudo apt-get install wkhtmltopdf``` 
+```$ sudo apt-get install wkhtmltopdf```
 
 should do the trick.
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ from pdfpy import PdfEngine
 def process():
 
 	if sys.argv[1].endswith(".epub"):
-		
+
+		print('--- Epub to PDF conversion started')
+
 		epub_file = sys.argv[1]
 		file = FileManager(epub_file)
 		file.epub_to_zip()
@@ -18,7 +20,7 @@ def process():
 		engine.get_pdf()
 		engine.get_css()
 		engine.get_images()
-		pdf = PdfEngine(engine.html_files, engine.css_files, 
+		pdf = PdfEngine(engine.html_files, engine.css_files,
 						engine.pdf_files, file.directory)
 		pdf.convert()
 		pdf.combine()
@@ -26,11 +28,12 @@ def process():
 		file.zip_to_epub()
 		file.del_directory()
 
+		print('--- Epub to PDF conversion successful')
+
 	else:
 
 		print("File is not an epub file")
-	
+
 
 if __name__ == "__main__":
 	process()
-

--- a/pdfpy.py
+++ b/pdfpy.py
@@ -32,11 +32,13 @@ class PdfEngine(object):
 		for each in self.markup_files:
 
 			# Prevent conversion process from showing terminal updates
-		
+
 			options = {'quiet': ''}
 
 			pdfkit.from_file(each, "{}.pdf".format(self.markup_files.index(each)),
 							 options=options)
+
+		print('--- Sections converted to pdf')
 
 	def combine(self):
 
@@ -50,6 +52,11 @@ class PdfEngine(object):
 
 		merger.write("{}.pdf".format(self.directory))
 
+		print('--- Sections combined together in a single pdf file')
+
+		merger.close()
+
 	def del_pdf(self):
 			for each in self.pdf_files:
 				os.remove(each)
+			print('--- Individual pdf files deleted from directory')


### PR DESCRIPTION
I added the close() function to PdfFileMerger object. Otherwise, single pdf files created within the repository couldn't be deleted after being merged as they were still used in memory by the class.

Also added a line in README about adding wkhtmltopdf in env path.