### PR TITLE
fix: fixes collections module import in getpy.py for python3.10

### DIFF
--- a/getpy.py
+++ b/getpy.py
@@ -1,3 +1,6 @@
+import collections.abc
+collections.Callable=collections.abc.Callable
+
 from bs4 import BeautifulSoup as bs
 import os
 import re


### PR DESCRIPTION
I was getting a collections.Callable error when I first run the project. This was how I was able to fix that error.