### PR TITLE
Add utf-8 encoding

### DIFF
--- a/getpy.py
+++ b/getpy.py
@@ -75,7 +75,7 @@ class GetEngine(object):
 		if not file:
 			return
 
-		xml_content = open(file, "r").read()
+		xml_content = open(file, "r", encoding="utf-8").read()
 
 		xml_tree = bs(xml_content, features = "xml")
 


### PR DESCRIPTION
Not all python default encoding is utf-8 (cp950 is also very common).
